### PR TITLE
command_chassis: Add SetChassisControlCommand

### DIFF
--- a/command_chassis.go
+++ b/command_chassis.go
@@ -55,6 +55,26 @@ func (c *GetChassisStatusCommand) Unmarshal(buf []byte) ([]byte, error) {
 	return nil, nil
 }
 
+// Set Chassis Power Command (Section 28.3)
+type SetChassisControlCommand struct {
+	// Request Data
+	PowerState uint8
+	// 0 - power down
+	// 1 - power up
+	// 2 - power cycle
+	// 3 - hard reset
+}
+
+func (c *SetChassisControlCommand) Name() string           { return "Set Chassis Power" }
+func (c *SetChassisControlCommand) Code() uint8            { return 0x02 }
+func (c *SetChassisControlCommand) NetFnRsLUN() NetFnRsLUN { return NewNetFnRsLUN(NetFnChassisReq, 0) }
+func (c *SetChassisControlCommand) String() string         { return cmdToJSON(c) }
+func (c *SetChassisControlCommand) Marshal() ([]byte, error) {
+	return []byte{c.PowerState}, nil
+}
+
+func (c *SetChassisControlCommand) Unmarshal(buf []byte) ([]byte, error) { return nil, nil }
+
 // Get System Restart Cause Command (Section 28.11)
 type GetSystemRestartCauseCommand struct {
 	// Response Data


### PR DESCRIPTION
Allow to power cycle a server.
original source: https://github.com/9elements/ipmigo/commit/a6c99d4ee89c113bb987c23a0c135f91025784fa

Signed-off-by: Patrick Rudolph <patrick.rudolph@9elements.com>